### PR TITLE
fix minimum setup type typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ or minimum setup (disables clicking to open waze):
 ```
 views:
   cards:
-    - type: custom:waze-cardq
+    - type: custom:waze-card
       entities:
         - entity: sensor.waze_home
         - entity: sensor.waze_work


### PR DESCRIPTION
remove `q` at the end of type in minimum setup configuration